### PR TITLE
fix only token and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ cloudshell_cm_customscript.egg-info/
 package/cloudshell_cm_customscript.egg-info/
 .vscode
 venv
+.venv*/
 dist
 *.stackdump

--- a/package/cloudshell/cm/customscript/customscript_shell.py
+++ b/package/cloudshell/cm/customscript/customscript_shell.py
@@ -64,7 +64,7 @@ class CustomScriptShell(object):
         """
         url = script_repo.url
         auth = None
-        if script_repo.username:
+        if script_repo.username or script_repo.token:
             auth = HttpAuth(script_repo.username, script_repo.password, script_repo.token)
         return ScriptDownloader(logger, cancel_sampler).download(url, auth)
 


### PR DESCRIPTION
fix for bug - Bug 180576: Configuration management step fails when using only 'token' for authentication with a github private repo.
the bug is that the condition on the download is only for username, added "or token" to enter also in the case just the token is provided. 