### PR TITLE
add auth with private-token patterna and test

### DIFF
--- a/package/cloudshell/cm/customscript/domain/script_downloader.py
+++ b/package/cloudshell/cm/customscript/domain/script_downloader.py
@@ -62,6 +62,17 @@ class ScriptDownloader(object):
 
             if response_valid:
                 file_name = self._get_filename(response)
+        
+        # try again with authorization {"Private-Token": "%s" % token}, since gitlab uses that pattern
+        if not response_valid and auth.token is not None:
+            self.logger.info("Token provided. Starting download script with Token (private-token pattern)...")
+            headers = {"Private-Token": "Bearer %s" % auth.token }
+            response = requests.get(url, stream=True, headers=headers, verify=verify_certificate)
+            
+            response_valid = self._is_response_valid(response, "Token")
+
+            if response_valid:
+                file_name = self._get_filename(response)
 
         # repo is private and credentials provided, and Token did not provided or did not work. this will NOT work for github. github require Token
         if not response_valid and (auth.username is not None and auth.password is not None):

--- a/package/tests/helpers.py
+++ b/package/tests/helpers.py
@@ -11,6 +11,7 @@ def mocked_requests_get(*args, **kwargs):
     repo_dict = {
         "public": 'https://raw.repocontentservice.com/SomeUser/SomePublicRepo/master/bashScript.sh', 
         "private_token": 'https://raw.repocontentservice.com/SomeUser/SomePrivateTokenRepo/master/bashScript.sh',
+        "private_token_auth_pattern": 'https://gitlab.mock.com/api/v4/SomeUser/SomePrivateTokenRepo/master/bashScript.sh',
         "private_cred": 'https://raw.repocontentservice.com/SomeUser/SomePrivateCredRepo/master/bashScript.sh',
         "content": 'SomeBashScriptContent'
     }
@@ -37,6 +38,15 @@ def mocked_requests_get(*args, **kwargs):
         if 'headers' in kwargs:
             if kwargs["headers"]["Authorization"] == 'Bearer 551e48b030e1a9f334a330121863e48e43f58c55':
                 response = MockResponse(repo_dict['content'], 200, {"Content-Type": "text/plain"}, repo_dict['private_token'])
+                return response
+    
+    if args[0] == repo_dict['private_token_auth_pattern']:
+        if 'headers' in kwargs:
+            if 'Authorization' in kwargs["headers"]:
+                response = MockResponse("error", 404, {"Content-Type": "text/plain"}, "error content")
+                return response        
+            elif kwargs["headers"]["Private-Token"] == 'Bearer 551e48b030e1a9f334a330121863e48e43f58c55':
+                response = MockResponse(repo_dict['content'], 200, {"Content-Type": "text/plain"}, repo_dict['private_token_auth_pattern'])
                 return response
 
     if args[0] == repo_dict['private_cred']:

--- a/package/tests/test_script_downloader.py
+++ b/package/tests/test_script_downloader.py
@@ -57,6 +57,21 @@ class TestScriptDownloader(TestCase):
         self.assertEqual(script_file.text, "SomeBashScriptContent")
 
     @mock.patch('cloudshell.cm.customscript.domain.script_downloader.requests.get', side_effect=mocked_requests_get)
+    def test_download_as_private_with_token_with_private_token_pattern(self, mocked_requests_get):
+        # private - url, with token
+        private_repo_url = 'https://gitlab.mock.com/api/v4/SomeUser/SomePrivateTokenRepo/master/bashScript.sh'
+        self.auth = HttpAuth('','','551e48b030e1a9f334a330121863e48e43f58c55')
+
+        # set downloaded and downaload
+        self.logger.info = print_logs
+        script_downloader = ScriptDownloader(self.logger, self.cancel_sampler)
+        script_file = script_downloader.download(private_repo_url, self.auth, True)
+
+        # assert name and content
+        self.assertEqual(script_file.name, "bashScript.sh")
+        self.assertEqual(script_file.text, "SomeBashScriptContent")
+
+    @mock.patch('cloudshell.cm.customscript.domain.script_downloader.requests.get', side_effect=mocked_requests_get)
     def test_download_as_private_with_credentials_and_failed_token(self, mocked_requests_get):
         # private - url, with token that fails and user\password. note - this is will not work on GitHub repo, they require token
         private_repo_url = 'https://raw.repocontentservice.com/SomeUser/SomePrivateCredRepo/master/bashScript.sh'


### PR DESCRIPTION
PBI 180193 - need to support gitlab and bitbucket. added a method just for gitlab pattern ('private-token') since current implementation should work for bitbucket and github in the current form.