### PR TITLE
fix for get filename from gitlab url structure

### DIFF
--- a/package/cloudshell/cm/customscript/domain/script_downloader.py
+++ b/package/cloudshell/cm/customscript/domain/script_downloader.py
@@ -133,6 +133,7 @@ class ScriptDownloader(object):
                 file_name = matching.group('filename')
 
         # fallback, couldn't find file name regular URL, check gitlab structure (filename in [-2] position)
+        # example for gitlab URL structure - '/repository/files/testfile%2Eps1/raw?ref=master'
         if not file_name:
             file_name_from_url = urllib.parse.unquote(response.url.split('/')[-2])
             matching = re.match(self.filename_pattern, file_name_from_url)

--- a/package/cloudshell/cm/customscript/domain/script_downloader.py
+++ b/package/cloudshell/cm/customscript/domain/script_downloader.py
@@ -132,6 +132,13 @@ class ScriptDownloader(object):
             if matching:
                 file_name = matching.group('filename')
 
+        # fallback, couldn't find file name regular URL, check gitlab structure (filename in [-2] position)
+        if not file_name:
+            file_name_from_url = urllib.parse.unquote(response.url.split('/')[-2])
+            matching = re.match(self.filename_pattern, file_name_from_url)
+            if matching:
+                file_name = matching.group('filename')
+
         if not file_name:
             raise Exception("Script file of supported types: '.sh', '.bash', '.ps1' was not found")
         return file_name.strip()

--- a/package/tests/helpers.py
+++ b/package/tests/helpers.py
@@ -13,6 +13,7 @@ def mocked_requests_get(*args, **kwargs):
         "private_token": 'https://raw.repocontentservice.com/SomeUser/SomePrivateTokenRepo/master/bashScript.sh',
         "private_token_auth_pattern": 'https://gitlab.mock.com/api/v4/SomeUser/SomePrivateTokenRepo/master/bashScript.sh',
         "private_cred": 'https://raw.repocontentservice.com/SomeUser/SomePrivateCredRepo/master/bashScript.sh',
+        "private_cred_gitlab_struct": 'https://gitlab.mock.com/api/v4/SomeUser/SomePrivateTokenRepo/master/bashScript%2Esh/raw?ref=master',
         "content": 'SomeBashScriptContent'
     }
 
@@ -47,6 +48,15 @@ def mocked_requests_get(*args, **kwargs):
                 return response        
             elif kwargs["headers"]["Private-Token"] == 'Bearer 551e48b030e1a9f334a330121863e48e43f58c55':
                 response = MockResponse(repo_dict['content'], 200, {"Content-Type": "text/plain"}, repo_dict['private_token_auth_pattern'])
+                return response
+                    
+    if args[0] == repo_dict['private_cred_gitlab_struct']:
+        if 'headers' in kwargs:
+            if 'Authorization' in kwargs["headers"]:
+                response = MockResponse("error", 404, {"Content-Type": "text/plain"}, "error content")
+                return response        
+            elif kwargs["headers"]["Private-Token"] == 'Bearer 551e48b030e1a9f334a330121863e48e43f58c55':
+                response = MockResponse(repo_dict['content'], 200, {"Content-Type": "text/plain"}, repo_dict['private_cred_gitlab_struct'])
                 return response
 
     if args[0] == repo_dict['private_cred']:

--- a/package/tests/test_script_downloader.py
+++ b/package/tests/test_script_downloader.py
@@ -72,6 +72,21 @@ class TestScriptDownloader(TestCase):
         self.assertEqual(script_file.text, "SomeBashScriptContent")
 
     @mock.patch('cloudshell.cm.customscript.domain.script_downloader.requests.get', side_effect=mocked_requests_get)
+    def test_download_as_private_with_token_with_gitlab_url_structure(self, mocked_requests_get):
+        # private - url, with token
+        private_repo_url = 'https://gitlab.mock.com/api/v4/SomeUser/SomePrivateTokenRepo/master/bashScript%2Esh/raw?ref=master'
+        self.auth = HttpAuth('','','551e48b030e1a9f334a330121863e48e43f58c55')
+
+        # set downloaded and downaload
+        self.logger.info = print_logs
+        script_downloader = ScriptDownloader(self.logger, self.cancel_sampler)
+        script_file = script_downloader.download(private_repo_url, self.auth, True)
+
+        # assert name and content
+        self.assertEqual(script_file.name, "bashScript.sh")
+        self.assertEqual(script_file.text, "SomeBashScriptContent")
+
+    @mock.patch('cloudshell.cm.customscript.domain.script_downloader.requests.get', side_effect=mocked_requests_get)
     def test_download_as_private_with_credentials_and_failed_token(self, mocked_requests_get):
         # private - url, with token that fails and user\password. note - this is will not work on GitHub repo, they require token
         private_repo_url = 'https://raw.repocontentservice.com/SomeUser/SomePrivateCredRepo/master/bashScript.sh'


### PR DESCRIPTION
gitlab url is different - filename is not the last item on the string, its the next to last. so added another fallback in the filename extractor to check for that, in case all other attepts failed. 