### PR TITLE
excpetion on auth=none and public download fails

### DIFF
--- a/package/cloudshell/cm/customscript/domain/script_downloader.py
+++ b/package/cloudshell/cm/customscript/domain/script_downloader.py
@@ -52,6 +52,10 @@ class ScriptDownloader(object):
         if response_valid:
             file_name = self._get_filename(response)
 
+        # if fails on public and no auth - no point carry on, user need to fix his URL or add credentials
+        if not response_valid and auth is None:
+            raise Exception('Please make sure the URL is valid, and the credentials are correct and necessary.')
+
         # repo is private and token provided
         if not response_valid and auth.token is not None:
             self.logger.info("Token provided. Starting download script with Token...")

--- a/package/tests/helpers.py
+++ b/package/tests/helpers.py
@@ -14,6 +14,7 @@ def mocked_requests_get(*args, **kwargs):
         "private_token_auth_pattern": 'https://gitlab.mock.com/api/v4/SomeUser/SomePrivateTokenRepo/master/bashScript.sh',
         "private_cred": 'https://raw.repocontentservice.com/SomeUser/SomePrivateCredRepo/master/bashScript.sh',
         "private_cred_gitlab_struct": 'https://gitlab.mock.com/api/v4/SomeUser/SomePrivateTokenRepo/master/bashScript%2Esh/raw?ref=master',
+        "bad_url": 'https://badurl.mock.com/SomePublicRepo/master/bashScript.sh',
         "content": 'SomeBashScriptContent'
     }
 
@@ -30,6 +31,9 @@ def mocked_requests_get(*args, **kwargs):
         def iter_content(self, chunk):
             yield bytes(self.json_data, 'utf-8')
             # return self.json_data
+
+    if args[0] == repo_dict['bad_url']:
+        response = MockResponse("error", 404, {"Content-Type": "text/plain"}, "error content")
 
     if args[0] == repo_dict['public']:
         response = MockResponse(repo_dict['content'], 200, {"Content-Type": "text/plain"}, repo_dict['public'])

--- a/package/tests/test_script_downloader.py
+++ b/package/tests/test_script_downloader.py
@@ -100,3 +100,23 @@ class TestScriptDownloader(TestCase):
         # assert name and content
         self.assertEqual(script_file.name, "bashScript.sh")
         self.assertEqual(script_file.text, "SomeBashScriptContent")
+
+    @mock.patch('cloudshell.cm.customscript.domain.script_downloader.requests.get', side_effect=mocked_requests_get)
+    def test_download_fails_public_with_no_credentials_throws_exception(self, mocked_requests_get):
+        # private - url, with token that fails and user\password. note - this is will not work on GitHub repo, they require token
+        private_repo_url = 'https://badurl.mock.com/SomePublicRepo/master/bashScript.sh'
+        self.auth = None
+
+        # set downloaded and downaload
+        self.logger.info = print_logs
+        script_downloader = ScriptDownloader(self.logger, self.cancel_sampler)
+        # script_file = script_downloader.download(private_repo_url, self.auth, True)
+
+        with self.assertRaises(Exception) as context:
+            script_downloader.download(private_repo_url, self.auth, True)
+
+        self.assertIn('Please make sure the URL is valid, and the credentials are correct and necessary.', str(context.exception))
+
+        # assert name and content
+        #self.assertEqual(script_file.name, "bashScript.sh")
+        #self.assertEqual(script_file.text, "SomeBashScriptContent")


### PR DESCRIPTION
for the use case of auth is none (user did not enter credentials) and the public download fails (URL is wrong) we should throw a nice exception and not "NoneType" - which was what happened since the auth wa None on the next download attempt. 