### PR TITLE
initial

### DIFF
--- a/package/cloudshell/cm/customscript/domain/reservation_output_writer.py
+++ b/package/cloudshell/cm/customscript/domain/reservation_output_writer.py
@@ -20,4 +20,5 @@ class ReservationOutputWriter(object):
 
     def _remove_illegal_chars(self, str):
         rx = re.compile('\x00')
+        str = str if not getattr(str, "decode", False) else str.decode()  # can be a bytes-like object
         return rx.sub('', str)

--- a/package/tests/test_reservation_output_writer.py
+++ b/package/tests/test_reservation_output_writer.py
@@ -14,3 +14,11 @@ class TestReservationOutputWriter(TestCase):
         writer = ReservationOutputWriter(session, context)
         writer.write('some msg')
         session.WriteMessageToReservationOutput.assert_called_once_with('1234','some msg')
+
+    def test_write_with_bytes(self):
+        session = Mock()
+        context = Mock()
+        context.reservation.reservation_id = '1234'
+        writer = ReservationOutputWriter(session, context)
+        writer.write(b'some msg')
+        session.WriteMessageToReservationOutput.assert_called_once_with('1234','some msg')


### PR DESCRIPTION
reservation output writer should be able to handle bytes and not just string