### PR TITLE
support redirects in githubusercontent due to cisco umbrella

### DIFF
--- a/package/cloudshell/cm/customscript/domain/script_downloader.py
+++ b/package/cloudshell/cm/customscript/domain/script_downloader.py
@@ -60,7 +60,9 @@ class ScriptDownloader(object):
         if not response_valid and auth.token is not None:
             self.logger.info("Token provided. Starting download script with Token...")
             headers = {"Authorization": "Bearer %s" % auth.token }
-            response = requests.get(url, stream=True, headers=headers, verify=verify_certificate)
+            response = requests.get(url, stream=True, headers=headers, verify=verify_certificate, allow_redirects=False)
+            while response.status_code==302:
+                response = requests.get(response.headers['location'], stream=True,headers=headers, verify=verify_certificate, allow_redirects=False)
             
             response_valid = self._is_response_valid(response, "Token")
 


### PR DESCRIPTION
explanation:
when downloading files form raw.githubusercontent.com, a github internal cisco umbrella server performs redirects in a way that causes the download through requests to fail (but not through curl (´;︵;`) )

by disabling the default allow redirects, and instead handling the redirect ourselves, but propagating the security token, we can ensure we eventually reach the destination with our token, cheers.

BTW, this problem does not reproduce from every machine when utilizing raw.githubusercontent.com, so a bit of a mystery